### PR TITLE
Implement account management page and favorite restrictions

### DIFF
--- a/lib/models/favorites_manager.dart
+++ b/lib/models/favorites_manager.dart
@@ -18,6 +18,11 @@ class FavoritesManager extends ChangeNotifier {
     }
     notifyListeners();
   }
+
+  void clearFavorites() {
+    _favorites.clear();
+    notifyListeners();
+  }
 }
 
 final FavoritesManager favoritesManager = FavoritesManager();

--- a/lib/models/user_account_manager.dart
+++ b/lib/models/user_account_manager.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+
+class UserAccountManager extends ChangeNotifier {
+  String? _nome;
+  String? _email;
+  String? _senha;
+
+  String? get nome => _nome;
+  String? get email => _email;
+  String? get senha => _senha;
+
+  bool get hasAccount => _nome != null && _email != null;
+
+  void saveAccount({required String nome, required String email, required String senha}) {
+    _nome = nome;
+    _email = email;
+    _senha = senha;
+    notifyListeners();
+  }
+}
+
+final UserAccountManager userAccountManager = UserAccountManager();

--- a/lib/screens/minha_conta_page.dart
+++ b/lib/screens/minha_conta_page.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import '../models/user_account_manager.dart';
+import '../models/favorites_manager.dart';
+
+class MinhaContaPage extends StatefulWidget {
+  final bool showFormInitially;
+  const MinhaContaPage({super.key, this.showFormInitially = false});
+
+  @override
+  State<MinhaContaPage> createState() => _MinhaContaPageState();
+}
+
+class _MinhaContaPageState extends State<MinhaContaPage> {
+  final _formKey = GlobalKey<FormState>();
+  late TextEditingController _nameController;
+  late TextEditingController _emailController;
+  late TextEditingController _passwordController;
+  bool _editing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: userAccountManager.nome);
+    _emailController = TextEditingController(text: userAccountManager.email);
+    _passwordController = TextEditingController(text: userAccountManager.senha);
+    _editing = widget.showFormInitially || !userAccountManager.hasAccount;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    if (_formKey.currentState!.validate()) {
+      userAccountManager.saveAccount(
+        nome: _nameController.text,
+        email: _emailController.text,
+        senha: _passwordController.text,
+      );
+      setState(() {
+        _editing = false;
+      });
+    }
+  }
+
+  void _confirmClearFavorites() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Limpar Favoritos'),
+        content: const Text('Tem certeza que deseja limpar os favoritos?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () {
+              favoritesManager.clearFavorites();
+              Navigator.pop(context);
+            },
+            child: const Text('Confirmar'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildForm() {
+    return Form(
+      key: _formKey,
+      child: Column(
+        children: [
+          TextFormField(
+            controller: _nameController,
+            decoration: const InputDecoration(labelText: 'Nome'),
+            validator: (value) =>
+                value == null || value.isEmpty ? 'Informe o nome' : null,
+          ),
+          TextFormField(
+            controller: _emailController,
+            decoration: const InputDecoration(labelText: 'Email'),
+            validator: (value) {
+              if (value == null || value.isEmpty) return 'Informe o email';
+              if (!value.contains('@')) return 'Email inválido';
+              return null;
+            },
+          ),
+          TextFormField(
+            controller: _passwordController,
+            decoration: const InputDecoration(labelText: 'Senha'),
+            obscureText: true,
+            validator: (value) =>
+                value == null || value.length < 4 ? 'Senha muito curta' : null,
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: _save,
+            child: const Text('Salvar'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Minha Conta')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            if (_editing)
+              _buildForm()
+            else if (userAccountManager.hasAccount) ...[
+              Text('Nome: ${userAccountManager.nome}'),
+              Text('Email: ${userAccountManager.email}'),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () {
+                  setState(() {
+                    _editing = true;
+                  });
+                },
+                child: const Text('Editar Dados'),
+              ),
+            ] else
+              ElevatedButton(
+                onPressed: () {
+                  setState(() {
+                    _editing = true;
+                  });
+                },
+                child: const Text('Criar Conta'),
+              ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _confirmClearFavorites,
+              child: const Text('Limpar Favoritos'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/product_card.dart
+++ b/lib/widgets/product_card.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import '../models/product.dart';
 import '../models/favorites_manager.dart';
+import '../models/user_account_manager.dart';
 import '../screens/product_details_screen.dart';
+import '../screens/minha_conta_page.dart';
 
 
 class ProductCard extends StatelessWidget {
@@ -48,7 +50,20 @@ class ProductCard extends StatelessWidget {
                   builder: (context, _) {
                     final isFav = favoritesManager.isFavorite(product);
                     return GestureDetector(
-                      onTap: () => favoritesManager.toggleFavorite(product),
+                      onTap: () {
+                        if (userAccountManager.hasAccount) {
+                          favoritesManager.toggleFavorite(product);
+                        } else {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const MinhaContaPage(
+                                showFormInitially: true,
+                              ),
+                            ),
+                          );
+                        }
+                      },
                       child: Icon(
                         isFav ? Icons.favorite : Icons.favorite_border,
                         color: Colors.deepPurple,


### PR DESCRIPTION
## Summary
- add a manager for user account data
- implement MinhaContaPage with form and favorite cleanup
- allow favorites to be cleared
- require account before favoriting an item

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f1dded10832d9e075d6fbdc362c4